### PR TITLE
Migrate to PEP 517-compatible packaging & fix dependency parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 woocommerce
 frappe
+requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,18 @@
+[metadata]
+name = woocommerceconnector
+version = attr: woocommerceconnector.__version__
+description = WooCommerce Connector for ERPNext
+author = libracore
+author_email = info@libracore.com
+long_description = file: README.md
+long_description_content_type = text/markdown
+
+[options]
+packages = find:
+zip_safe = False
+include_package_data = True
+install_requires =
+    -r requirements.txt
+
+[options.package_data]
+* = *.json, *.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,9 @@ packages = find:
 zip_safe = False
 include_package_data = True
 install_requires =
-    -r requirements.txt
+    frappe
+    requests
+    woocommerce
 
 [options.package_data]
 * = *.json, *.md

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,4 @@
 # -*- coding: utf-8 -*-
-from setuptools import setup, find_packages
-try: # for pip >= 10
-   from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
-   from pip.req import parse_requirements
-import re, ast
+from setuptools import setup
 
-# get version from __version__ variable in woocommerceconnector/__init__.py
-_version_re = re.compile(r'__version__\s+=\s+(.*)')
-
-with open('woocommerceconnector/__init__.py', 'rb') as f:
-    version = str(ast.literal_eval(_version_re.search(
-        f.read().decode('utf-8')).group(1)))
-
-with open('requirements.txt') as f:
-	install_requires = f.read().strip().split('\n')
-
-setup(
-	name='woocommerceconnector',
-	version=version,
-	description='WooCommerce Connector for ERPNext',
-	author='libracore',
-	author_email='info@libracore.com',
-	packages=find_packages(),
-	zip_safe=False,
-	include_package_data=True,
-	install_requires=install_requires
-)
+setup()


### PR DESCRIPTION
## Changes
### **1. PEP 517 / Modern Packaging Support**
- Added **pyproject.toml** with setuptools backend support.
- Added **setup.cfg** to manage metadata, dependencies, and package metadata.
- Simplified **setup.py** to a minimal entry point for backward compatibility.
- Removed deprecated `pip._internal.req.parse_requirements` usage.
- Delegated dependency management to `requirements.txt`.

### **2. Fixed `InvalidRequirement` Error**
- Removed usage of `-r requirements.txt` inside `install_requires`.
- Explicitly declared dependencies in `setup.cfg`.
- Resolved:
```
packaging.requirements.InvalidRequirement: Expected package name at the start of dependency specifier
-r requirements.txt
^
```

## Why
- `setup.py develop` and direct `-r` usage are deprecated and incompatible with **pip ≥ 24**.
- Bench ≥ 5.25 and ERPNext 15+ require **PEP 517-compatible builds**.
- Ensures smooth installation using:
```bash
bench get-app https://github.com/navariltd/WooCommerceConnector.git